### PR TITLE
Pass sources as a list to on_demand_feature_view

### DIFF
--- a/feature_repo/features.py
+++ b/feature_repo/features.py
@@ -63,10 +63,10 @@ input_request = RequestSource(
 # Define an on demand feature view which can generate new features based on
 # existing feature views and RequestSource features
 @on_demand_feature_view(
-    sources={
-        "driver_hourly_stats": driver_hourly_stats_view,
-        "vals_to_add": input_request,
-    },
+    sources=[
+        driver_hourly_stats_view,
+        input_request,
+    ],
     schema=[
         Field(name="conv_rate_plus_val1", dtype=Float64),
         Field(name="conv_rate_plus_val2", dtype=Float64),


### PR DESCRIPTION
`@on_demand_feature_view` now take expect a list of `sources`, as mentioned in the documentation [here](https://docs.feast.dev/reference/alpha-on-demand-feature-view#registering-transformations). 

Using a dictionary fails on Feast 0.22.1